### PR TITLE
Fixed cookie in combination with filter-control + strict search

### DIFF
--- a/src/extensions/cookie/bootstrap-table-cookie.js
+++ b/src/extensions/cookie/bootstrap-table-cookie.js
@@ -179,8 +179,10 @@
 
                     applyCookieFilters = function (element, filteredCookies) {
                         $(filteredCookies).each(function (i, cookie) {
+                            if (cookie.text !== '') {
                                 $(element).val(cookie.text);
                                 cachedFilters[cookie.field] = cookie.text;
+                            }                                
                         });
                     };
 


### PR DESCRIPTION
When using cookie in combination with filter-control and strict search enabled on a column, selecting the empty value would store it as an empty value in cookie. When returning the page and thus getting the cookie, it would result in no results in bootstrap-table because it would literally search for ''.